### PR TITLE
Fix a segfault when there is no GPS fix

### DIFF
--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -178,7 +178,7 @@ class GPSDClient {
 
       /* TODO: Support SBAS and other GBAS. */
 
-      if (use_gps_time)
+      if (use_gps_time && !isnan(p->fix.time))
         fix->header.stamp = ros::Time(p->fix.time);
       else
         fix->header.stamp = ros::Time::now();


### PR DESCRIPTION
This segfault is caused by the value for time. It will be NaN whenever there is no current satellite fix, which causes the ROS timestamp message to throw a Boost rounding exception. This check prevents the error from occurring.
