### PR TITLE
Fixing orientation in UTM odometry message

### DIFF
--- a/gps_common/src/utm_odometry_node.cpp
+++ b/gps_common/src/utm_odometry_node.cpp
@@ -46,10 +46,10 @@ void callback(const sensor_msgs::NavSatFixConstPtr& fix) {
     odom.pose.pose.position.y = northing;
     odom.pose.pose.position.z = fix->altitude;
     
-    odom.pose.pose.orientation.x = 1;
+    odom.pose.pose.orientation.x = 0;
     odom.pose.pose.orientation.y = 0;
     odom.pose.pose.orientation.z = 0;
-    odom.pose.pose.orientation.w = 0;
+    odom.pose.pose.orientation.w = 1;
     
     // Use ENU covariance to build XYZRPY covariance
     boost::array<double, 36> covariance = {{


### PR DESCRIPTION
Before the fix, the orientation in the odometry message was set to x = 1, y = 0, z = 0, w = 0. This corresponds to Euler angles of roll = pi, pitch = 0, yaw = 0. I believe the intent was for the orientation to be the identity (Euler angles of roll = 0, pitch = 0, yaw = 0), which is x = 0, y = 0, z = 0, w = 1.
